### PR TITLE
Update Gemini API URL

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -61,7 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        const API_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`;
+        const API_URL = `https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent?key=${apiKey}`;
         aiResponse.textContent = 'AI가 생각 중입니다...';
 
         try {


### PR DESCRIPTION
## Summary
- update Gemini endpoint to supported v1 URL

## Testing
- `node tests/app.test.js` *(fails: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6841bef39b28832c9a686e9c41279771