### PR TITLE
Fix bottom scroll area by adding padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
             flex-direction: column;
             align-items: center; 
             padding: 40px; 
+            padding-bottom: 120px; /* 하단 툴바 높이만큼 여백 확보 */
             gap: 30px;
             width: 100%;
             overflow-y: auto; 
@@ -335,7 +336,7 @@
 
         @media (max-width: 768px) {
             .header { font-size: 2rem; padding: 15px; }
-            .content-area { padding: 20px;}
+            .content-area { padding: 20px; padding-bottom: 120px; }
             .main-button { font-size: 2rem; padding: 30px; }
             .main-button-icon { font-size: 4rem; }
             .screen-title { font-size: 2rem; }


### PR DESCRIPTION
## Summary
- update `.content-area` padding so the bottom toolbar doesn't block scroll content
- ensure small screens also get bottom padding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68423965b2b8832ca59ebfb1923bdfa5