### PR TITLE
Implement Flask backend and update frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,16 @@
    git clone <repository-url>
    cd Kiosk2
    ```
-2. `index.html`을 브라우저에서 열어 실행합니다. 로컬 HTTP 서버를 이용하면 더 안정적으로 동작합니다.
+2. 백엔드 서버를 실행합니다. 환경 변수 `GEMINI_API_KEY`에 API 키를 설정한 뒤 Flask 서버를 구동합니다.
    ```bash
-   # 예: Python 3 사용 시
+   export GEMINI_API_KEY="<YOUR-KEY>"
+   python server.py
+   ```
+3. 다른 터미널에서 프런트엔드를 호스팅합니다.
+   ```bash
    python -m http.server
    # 브라우저에서 http://localhost:8000 접속
    ```
-3. AI 챗봇을 사용하려면 `index.html`의 `const apiKey = "";` 부분에 본인의 Gemini API 키를 입력합니다.
 4. 브라우저에서 각 메뉴를 눌러 기능을 테스트하고, "AI 챗봇" 버튼을 눌러 질문을 해 보세요.
 
 ## 커스터마이징

--- a/index.html
+++ b/index.html
@@ -761,7 +761,6 @@
                 }
             }
 
-            const apiKey = ""; 
             // Modified prompt to guide Gemini for general and specific questions
             const C_promptForGemini = `You are a helpful AI assistant integrated into a health kiosk. 
 An image of the kiosk screen the user is currently viewing may be provided. The user's question is: "${question}".
@@ -786,13 +785,11 @@ Please provide a comprehensive and helpful answer in Korean.`;
                 });
             }
 
-            const payload = {
-                contents: [{ role: "user", parts: parts }],
-                // generationConfig: { // Optional: to specify output language if needed, but model should infer from prompt.
-                //    "response_mime_type": "text/plain"
-                // }
-            };
-            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
+            const payload = { question: C_promptForGemini };
+            if (base64ImageData) {
+                payload.image = base64ImageData;
+            }
+            const apiUrl = `/api/ask`;
 
             try {
                 const response = await fetch(apiUrl, {

--- a/server.py
+++ b/server.py
@@ -1,0 +1,36 @@
+import os
+from flask import Flask, request, jsonify
+import requests
+from flask_cors import CORS
+
+app = Flask(__name__)
+CORS(app)
+
+GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY")
+if not GEMINI_API_KEY:
+    raise RuntimeError("GEMINI_API_KEY environment variable is not set")
+
+GEMINI_URL = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key={GEMINI_API_KEY}"
+
+@app.route('/api/ask', methods=['POST'])
+def ask():
+    data = request.get_json(force=True)
+    question = data.get('question', '')
+    base64_image = data.get('image')
+
+    parts = [{"text": question}]
+    if base64_image:
+        parts.append({
+            "inlineData": {
+                "mimeType": "image/jpeg",
+                "data": base64_image
+            }
+        })
+
+    payload = {"contents": [{"role": "user", "parts": parts}]}
+
+    resp = requests.post(GEMINI_URL, json=payload)
+    return jsonify(resp.json()), resp.status_code
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add `server.py` Flask backend to proxy Gemini API requests
- update `index.html` to call new `/api/ask` endpoint
- document running backend with `GEMINI_API_KEY` in README

## Testing
- `python -m py_compile server.py`
- `python server.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684289d019b8832c91b96bc9c1ab98fb